### PR TITLE
D8UN-3111

### DIFF
--- a/project/sites/nicswell/themes/nicswell_theme/templates/content/node--video--full.html.twig
+++ b/project/sites/nicswell/themes/nicswell_theme/templates/content/node--video--full.html.twig
@@ -84,12 +84,6 @@
     </div>
   {% endif %}
 
-  {% if content.field_photo %}
-    <div class="video-image">
-      {{ content.field_photo }}
-    </div>
-  {% endif %}
-
   {% if content.field_video %}
     <div class="video-embed">
       {{ content.field_video }}


### PR DESCRIPTION
- Removing the image field from display on full video pages.
- Image still appears on search result (as per ticket)