### PR TITLE
Fixing Unity 4 edge failure

### DIFF
--- a/project/config/proni/config/core.extension.yml
+++ b/project/config/proni/config/core.extension.yml
@@ -101,7 +101,6 @@ module:
   origins_qa: 0
   origins_search_views_routing: 0
   origins_toc: 0
-  origins_forms: 0
   page_cache: 0
   path: 0
   path_alias: 0


### PR DESCRIPTION
- Removing duplicate module in Core Extension cause edge build failure - PRONI