### PR TITLE
D8UN-3556

### DIFF
--- a/project/sites/cusubt/themes/cusubt_theme/logo.svg
+++ b/project/sites/cusubt/themes/cusubt_theme/logo.svg
@@ -25,10 +25,10 @@
 		<text xml:space="preserve" font-family="Arial, Helvetica, sans-serif" font-size="20" font-style="normal" font-weight="600" style="stroke: none; stroke-width: 1; stroke-dasharray: none; stroke-linecap: butt; stroke-dashoffset: 0; stroke-linejoin: miter; stroke-miterlimit: 4; fill: rgb(0,0,0); fill-rule: nonzero; opacity: 1; white-space: pre;" ><tspan x="-130.58" y="6.28" >Office of the Commissioner</tspan></text>
 </g>
 		<g transform="matrix(1 0 0 1 117.24 -6.27)" style=""  >
-		<text xml:space="preserve" font-family="Arial, Helvetica, sans-serif" font-size="20" font-style="normal" font-weight="600" style="stroke: none; stroke-width: 1; stroke-dasharray: none; stroke-linecap: butt; stroke-dashoffset: 0; stroke-linejoin: miter; stroke-miterlimit: 4; fill: rgb(0,0,0); fill-rule: nonzero; opacity: 1; white-space: pre;" ><tspan x="-102.24" y="6.28" >for the Ulster Scots &amp;</tspan></text>
+		<text xml:space="preserve" font-family="Arial, Helvetica, sans-serif" font-size="20" font-style="normal" font-weight="600" style="stroke: none; stroke-width: 1; stroke-dasharray: none; stroke-linecap: butt; stroke-dashoffset: 0; stroke-linejoin: miter; stroke-miterlimit: 4; fill: rgb(0,0,0); fill-rule: nonzero; opacity: 1; white-space: pre;" ><tspan x="-102.24" y="6.28" >for the Ulster-Scots &amp;</tspan></text>
 </g>
 		<g transform="matrix(1 0 0 1 140.57 18.73)" style=""  >
-		<text xml:space="preserve" font-family="Arial, Helvetica, sans-serif" font-size="20" font-style="normal" font-weight="600" style="stroke: none; stroke-width: 1; stroke-dasharray: none; stroke-linecap: butt; stroke-dashoffset: 0; stroke-linejoin: miter; stroke-miterlimit: 4; fill: rgb(0,0,0); fill-rule: nonzero; opacity: 1; white-space: pre;" ><tspan x="-125.57" y="6.28" >the Ulster British Tradition</tspan></text>
+		<text xml:space="preserve" font-family="Arial, Helvetica, sans-serif" font-size="20" font-style="normal" font-weight="600" style="stroke: none; stroke-width: 1; stroke-dasharray: none; stroke-linecap: butt; stroke-dashoffset: 0; stroke-linejoin: miter; stroke-miterlimit: 4; fill: rgb(0,0,0); fill-rule: nonzero; opacity: 1; white-space: pre;" ><tspan x="-125.57" y="6.28" >the Ulster-British Tradition</tspan></text>
 </g>
 </g>
 </g>


### PR DESCRIPTION
- Ulster Scots Logo update - Ulster Scots and Ulster British both hyphenated as requested by Customer