### PR TITLE
D8UN-3543 (D8UN-3550 - Unity 4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,4 +12,4 @@
 | Truth Recovery Strategy | truthrecoverystrategy | truthrecoverystrategy.com | ![#fff3e0](https://placehold.co/140x30/ffe0b2/e65100.png?text=Development&font=source-sans-pro) |   | 
 | CUSUBT | cusubt | cusubt.org.uk | ![#fff3e0](https://placehold.co/140x30/ffe0b2/e65100.png?text=Development&font=source-sans-pro) |   | 
 | Truth Recovery Redress | truthrecoveryredress | truthrecoveryredress.org | ![#fff3e0](https://placehold.co/140x30/ffe0b2/e65100.png?text=Development&font=source-sans-pro) |   | 
-Last updated: 30/07/2026 06:49
+Last updated: 18/08/2026 13:51

--- a/project/config/anotherway/config/core.extension.yml
+++ b/project/config/anotherway/config/core.extension.yml
@@ -83,6 +83,7 @@ module:
   origins_ckeditor_enhancements: 0
   origins_common: 0
   origins_forms: 0
+  origins_internal_link_checker: 0
   origins_media: 0
   origins_metatag: 0
   origins_qa: 0
@@ -113,7 +114,6 @@ module:
   unity_eu_cookie_compliance: 0
   unity_frontpage: 0
   unity_image_styles: 0
-  unity_internal_link_checker: 0
   user: 0
   views_custom_cache_tag: 0
   webform: 0

--- a/project/config/autismreviewerni/config/core.extension.yml
+++ b/project/config/autismreviewerni/config/core.extension.yml
@@ -84,12 +84,13 @@ module:
   options: 0
   origins_ckeditor_enhancements: 0
   origins_common: 0
+  origins_forms: 0
+  origins_internal_link_checker: 0
   origins_media: 0
   origins_metatag: 0
   origins_qa: 0
   origins_search_views_routing: 0
   origins_toc: 0
-  origins_forms: 0
   page_cache: 0
   path: 0
   path_alias: 0
@@ -116,7 +117,6 @@ module:
   unity_eu_cookie_compliance: 0
   unity_frontpage: 0
   unity_image_styles: 0
-  unity_internal_link_checker: 0
   unity_search_pages: 0
   user: 0
   views_custom_cache_tag: 0

--- a/project/config/coimisineir/config/core.extension.yml
+++ b/project/config/coimisineir/config/core.extension.yml
@@ -90,6 +90,7 @@ module:
   origins_ckeditor_enhancements: 0
   origins_common: 0
   origins_forms: 0
+  origins_internal_link_checker: 0
   origins_media: 0
   origins_metatag: 0
   origins_qa: 0
@@ -122,7 +123,6 @@ module:
   unity_eu_cookie_compliance: 0
   unity_frontpage: 0
   unity_image_styles: 0
-  unity_internal_link_checker: 0
   unity_search_pages: 0
   user: 0
   views_custom_cache_tag: 0

--- a/project/config/cusubt/config/core.extension.yml
+++ b/project/config/cusubt/config/core.extension.yml
@@ -87,6 +87,7 @@ module:
   origins_ckeditor_enhancements: 0
   origins_common: 0
   origins_forms: 0
+  origins_internal_link_checker: 0
   origins_media: 0
   origins_metatag: 0
   origins_qa: 0
@@ -118,7 +119,6 @@ module:
   unity_eu_cookie_compliance: 0
   unity_frontpage: 0
   unity_image_styles: 0
-  unity_internal_link_checker: 0
   user: 0
   views_custom_cache_tag: 0
   webform: 0

--- a/project/config/legalcommissionerni/config/core.extension.yml
+++ b/project/config/legalcommissionerni/config/core.extension.yml
@@ -84,12 +84,13 @@ module:
   options: 0
   origins_ckeditor_enhancements: 0
   origins_common: 0
+  origins_forms: 0
+  origins_internal_link_checker: 0
   origins_media: 0
   origins_metatag: 0
   origins_qa: 0
   origins_search_views_routing: 0
   origins_toc: 0
-  origins_forms: 0
   page_cache: 0
   path: 0
   path_alias: 0

--- a/project/config/nicswell/config/core.extension.yml
+++ b/project/config/nicswell/config/core.extension.yml
@@ -94,6 +94,7 @@ module:
   origins_ckeditor_enhancements: 0
   origins_common: 0
   origins_forms: 0
+  origins_internal_link_checker: 0
   origins_media: 0
   origins_metatag: 0
   origins_qa: 0
@@ -133,7 +134,6 @@ module:
   unity_eu_cookie_compliance: 0
   unity_frontpage: 0
   unity_image_styles: 0
-  unity_internal_link_checker: 0
   unity_landing_pages: 0
   unity_search_pages: 0
   user: 0

--- a/project/config/oice/config/core.extension.yml
+++ b/project/config/oice/config/core.extension.yml
@@ -81,11 +81,12 @@ module:
   options: 0
   origins_ckeditor_enhancements: 0
   origins_common: 0
+  origins_forms: 0
+  origins_internal_link_checker: 0
   origins_media: 0
   origins_metatag: 0
   origins_qa: 0
   origins_toc: 0
-  origins_forms: 0
   page_cache: 0
   path: 0
   path_alias: 0
@@ -112,7 +113,6 @@ module:
   unity_eu_cookie_compliance: 0
   unity_frontpage: 0
   unity_image_styles: 0
-  unity_internal_link_checker: 0
   user: 0
   views_custom_cache_tag: 0
   whatlinkshere: 0

--- a/project/config/proni/config/core.extension.yml
+++ b/project/config/proni/config/core.extension.yml
@@ -97,6 +97,7 @@ module:
   origins_ckeditor_enhancements: 0
   origins_common: 0
   origins_forms: 0
+  origins_internal_link_checker: 0
   origins_media: 0
   origins_metatag: 0
   origins_qa: 0
@@ -140,7 +141,6 @@ module:
   unity_eu_cookie_compliance: 0
   unity_frontpage: 0
   unity_image_styles: 0
-  unity_internal_link_checker: 0
   unity_landing_pages: 0
   unity_search_pages: 0
   user: 0

--- a/project/config/truthrecoveryredress/config/core.extension.yml
+++ b/project/config/truthrecoveryredress/config/core.extension.yml
@@ -88,6 +88,7 @@ module:
   origins_ckeditor_enhancements: 0
   origins_common: 0
   origins_forms: 0
+  origins_internal_link_checker: 0
   origins_media: 0
   origins_metatag: 0
   origins_qa: 0
@@ -118,7 +119,6 @@ module:
   unity_eu_cookie_compliance: 0
   unity_frontpage: 0
   unity_image_styles: 0
-  unity_internal_link_checker: 0
   unity_search_pages: 0
   user: 0
   views_custom_cache_tag: 0

--- a/project/config/truthrecoverystrategy/config/core.extension.yml
+++ b/project/config/truthrecoverystrategy/config/core.extension.yml
@@ -86,11 +86,12 @@ module:
   options: 0
   origins_ckeditor_enhancements: 0
   origins_common: 0
+  origins_forms: 0
+  origins_internal_link_checker: 0
   origins_media: 0
   origins_metatag: 0
   origins_qa: 0
   origins_toc: 0
-  origins_forms: 0
   page_cache: 0
   path: 0
   path_alias: 0
@@ -117,7 +118,6 @@ module:
   unity_eu_cookie_compliance: 0
   unity_frontpage: 0
   unity_image_styles: 0
-  unity_internal_link_checker: 0
   unity_search_pages: 0
   user: 0
   views_custom_cache_tag: 0


### PR DESCRIPTION
- Unity Internal Link checker module uninstalled on all Unity 4 sites
- Origins Internal Link checker module installed on all Unity 4 sites
- No config existed on any of these sites for the previous module.